### PR TITLE
feat: add image processing preview with PDF size estimate

### DIFF
--- a/src/ui/preview_dialog.py
+++ b/src/ui/preview_dialog.py
@@ -1,0 +1,175 @@
+"""ImagePreviewDialog — Before/After comparison of image processing results."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QImage, QPixmap
+from PySide6.QtWidgets import (
+    QApplication,
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
+
+from .constants import BG_GRAY, BORDER_LIGHT, TEXT_MUTED, TEXT_PRI, WHITE
+from .preview_worker import PreviewSample
+
+# Horizontal space consumed outside the two image columns
+# dialog margins(16+16) + scroll margins(10+10) + row margins(12+12) + col margins(8+8)×2 + gap(12)
+_H_OVERHEAD = 140
+# Vertical space consumed outside the image itself inside one column
+# top margin(6) + title label(20) + spacing(4) + bottom margin(8)
+_COL_V_OVERHEAD = 38
+
+
+def _to_pixmap(img: np.ndarray) -> QPixmap:
+    img = np.ascontiguousarray(img)
+    if img.ndim == 2:
+        h, w = img.shape
+        qimg = QImage(img.tobytes(), w, h, w, QImage.Format.Format_Grayscale8)
+    else:
+        rgb = np.ascontiguousarray(cv2.cvtColor(img, cv2.COLOR_BGR2RGB))
+        h, w, _ = rgb.shape
+        qimg = QImage(rgb.tobytes(), w, h, w * 3, QImage.Format.Format_RGB888)
+    return QPixmap.fromImage(qimg)
+
+
+def _screen_col_width() -> int:
+    """Width each image column gets when the dialog is maximised."""
+    screen_w = QApplication.primaryScreen().availableSize().width()
+    return max(1, (screen_w - _H_OVERHEAD) // 2)
+
+
+class _SampleRow(QWidget):
+    def __init__(self, sample: PreviewSample, col_width: int) -> None:
+        super().__init__()
+        self._build(sample, col_width)
+
+    def _build(self, sample: PreviewSample, col_width: int) -> None:
+        self.setStyleSheet(
+            f"background:{WHITE}; border:1px solid {BORDER_LIGHT}; border-radius:8px;"
+        )
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(12, 10, 12, 10)
+        layout.setSpacing(6)
+
+        # Header
+        name_row = QHBoxLayout()
+        name_row.setSpacing(12)
+        name_lbl = QLabel(Path(sample.path).name)
+        name_lbl.setStyleSheet(
+            f"font-size:11px; font-weight:600; color:{TEXT_PRI}; background:transparent;"
+        )
+        size_lbl = QLabel(f"処理後 {sample.after_bytes / 1024:.0f} KB")
+        size_lbl.setStyleSheet(
+            f"font-size:10px; color:{TEXT_MUTED}; background:transparent;"
+        )
+        name_row.addWidget(name_lbl, stretch=1)
+        name_row.addWidget(size_lbl)
+        layout.addLayout(name_row)
+
+        # Before / After columns
+        img_row = QHBoxLayout()
+        img_row.setSpacing(12)
+        for title, img in [("処理前", sample.before), ("処理後", sample.after)]:
+            px = _to_pixmap(img)
+            img_h = round(col_width * px.height() / max(px.width(), 1))
+            scaled = px.scaled(
+                col_width, img_h,
+                Qt.AspectRatioMode.KeepAspectRatio,
+                Qt.TransformationMode.SmoothTransformation,
+            )
+
+            col = QWidget()
+            col.setStyleSheet(f"background:{BG_GRAY}; border-radius:6px;")
+            col_layout = QVBoxLayout(col)
+            col_layout.setContentsMargins(8, 6, 8, 8)
+            col_layout.setSpacing(4)
+
+            title_lbl = QLabel(title)
+            title_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            title_lbl.setStyleSheet(
+                f"font-size:11px; font-weight:600; color:{TEXT_PRI}; background:transparent;"
+            )
+            col_layout.addWidget(title_lbl)
+
+            img_lbl = QLabel()
+            img_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            img_lbl.setFixedSize(col_width, img_h + _COL_V_OVERHEAD)
+            img_lbl.setPixmap(scaled)
+            img_lbl.setStyleSheet("background:transparent;")
+            col_layout.addWidget(img_lbl)
+
+            img_row.addWidget(col)
+        layout.addLayout(img_row)
+
+
+class ImagePreviewDialog(QDialog):
+    """Maximised dialog showing Before/After pairs and estimated PDF size."""
+
+    def __init__(
+        self,
+        samples: list[PreviewSample],
+        estimated_mb: float,
+        total_count: int,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("仕上がり確認")
+        self._build(samples, estimated_mb, total_count)
+        self.showMaximized()
+
+    def _build(
+        self,
+        samples: list[PreviewSample],
+        estimated_mb: float,
+        total_count: int,
+    ) -> None:
+        col_width = _screen_col_width()
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        avg_kb = (
+            sum(s.after_bytes for s in samples) / len(samples) / 1024
+            if samples else 0
+        )
+        summary = QLabel(
+            f"📄 推定PDFサイズ（画像のみ）: 約 {estimated_mb:.1f} MB"
+            f"  （全 {total_count} 枚 × 平均 {avg_kb:.0f} KB/枚）"
+            f"  ※ サンプル {len(samples)} 件から推定"
+        )
+        summary.setStyleSheet(
+            f"font-size:13px; font-weight:600; color:{TEXT_PRI};"
+            f" background:{BG_GRAY}; padding:10px 14px; border-radius:8px;"
+        )
+        layout.addWidget(summary)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(Qt.ScrollBarPolicy.ScrollBarAlwaysOff)
+        scroll.setStyleSheet(
+            f"QScrollArea {{ border:1px solid {BORDER_LIGHT}; border-radius:8px;"
+            f" background:{WHITE}; }}"
+        )
+
+        container = QWidget()
+        container.setStyleSheet(f"background:{WHITE};")
+        container_layout = QVBoxLayout(container)
+        container_layout.setContentsMargins(10, 10, 10, 10)
+        container_layout.setSpacing(12)
+
+        for sample in samples:
+            container_layout.addWidget(_SampleRow(sample, col_width))
+        container_layout.addStretch()
+
+        scroll.setWidget(container)
+        layout.addWidget(scroll, stretch=1)

--- a/src/ui/preview_worker.py
+++ b/src/ui/preview_worker.py
@@ -1,0 +1,80 @@
+"""PreviewWorker — background thread that processes up to 10 sample images."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import cv2
+import numpy as np
+from PIL import Image
+from PySide6.QtCore import QThread, Signal
+
+from image_processing import resize_image, transform_intensity
+
+from .run_options import RunOptions
+
+
+@dataclass
+class PreviewSample:
+    path: str
+    before: np.ndarray   # BGR or grayscale
+    after: np.ndarray    # BGR or grayscale
+    after_bytes: int     # JPEG size after processing
+
+
+class PreviewWorker(QThread):
+    """Load + process sample images and emit results."""
+
+    finished = Signal(list, float)  # list[PreviewSample], estimated_mb
+    error = Signal(str)
+
+    def __init__(
+        self,
+        paths: list[str],
+        options: RunOptions,
+        total_count: int,
+    ) -> None:
+        super().__init__()
+        self._paths = paths
+        self._options = options
+        self._total_count = total_count
+
+    def run(self) -> None:
+        try:
+            samples: list[PreviewSample] = []
+            for path in self._paths:
+                before = _load(path)
+                after = _apply(before, self._options)
+                after_bytes = _jpeg_size(after, self._options.jpeg_quality)
+                samples.append(PreviewSample(path, before, after, after_bytes))
+
+            avg_bytes = sum(s.after_bytes for s in samples) / len(samples) if samples else 0
+            estimated_mb = avg_bytes * self._total_count / (1024 * 1024)
+            self.finished.emit(samples, estimated_mb)
+        except Exception as exc:
+            self.error.emit(str(exc))
+
+
+def _load(path: str) -> np.ndarray:
+    with Image.open(path) as pil_img:
+        img = np.array(pil_img)
+    if img.ndim == 3:
+        img = cv2.cvtColor(img, cv2.COLOR_RGB2BGR)
+    return img
+
+
+def _apply(img: np.ndarray, opts: RunOptions) -> np.ndarray:
+    if opts.contrast_adjust:
+        img = transform_intensity(img, brightness=opts.brightness, gamma=opts.gamma)
+    if opts.resize_width or opts.resize_height:
+        img = resize_image(
+            img,
+            target_width=opts.resize_width,
+            target_height=opts.resize_height,
+        )
+    return img
+
+
+def _jpeg_size(img: np.ndarray, quality: int) -> int:
+    ok, buf = cv2.imencode(".jpg", img, [cv2.IMWRITE_JPEG_QUALITY, quality])
+    return int(len(buf)) if ok else 0

--- a/src/ui/wizard_panel.py
+++ b/src/ui/wizard_panel.py
@@ -251,6 +251,23 @@ class WizardPanel(QWidget):
         layout.addWidget(self._make_contrast_section())
         layout.addWidget(self._make_resize_section())
 
+        self._preview_btn = QPushButton("🔍  仕上がり確認")
+        self._preview_btn.setFixedHeight(40)
+        self._preview_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._preview_btn.setEnabled(False)
+        self._preview_btn.setStyleSheet(f"""
+            QPushButton {{
+                background:#F0F5FF; color:#6366F1;
+                border:1px solid #C7D2FE; border-radius:10px;
+                font-size:13px; font-weight:600;
+            }}
+            QPushButton:hover {{ background:#E0E7FF; }}
+            QPushButton:pressed {{ background:#C7D2FE; }}
+            QPushButton:disabled {{ background:{BG_GRAY}; color:{TEXT_MUTED}; border-color:{BORDER_LIGHT}; }}
+        """)
+        self._preview_btn.clicked.connect(self._on_preview_clicked)
+        layout.addWidget(self._preview_btn)
+
         sep = QWidget()
         sep.setFixedHeight(1)
         sep.setStyleSheet(f"background:{BORDER};")
@@ -663,6 +680,7 @@ class WizardPanel(QWidget):
         self._load_label.setVisible(False)
         self._clear_row.setVisible(False)
         self._drop_zone.setVisible(True)
+        self._preview_btn.setEnabled(False)
         self._step1.set_active()
         self._step2.set_locked()
         self._step3.set_locked()
@@ -675,6 +693,7 @@ class WizardPanel(QWidget):
         n = len(self._files)
         self._clear_row.setVisible(has_files)
         self._drop_zone.setVisible(not has_files)
+        self._preview_btn.setEnabled(has_files)
         if has_files:
             self._step1.set_completed(f"{n} ファイル選択済み")
             self._step2.set_active()
@@ -701,6 +720,34 @@ class WizardPanel(QWidget):
         return btn
 
     # ── Button handlers ────────────────────────────────────────────────────────
+
+    def _on_preview_clicked(self) -> None:
+        if not self._files:
+            return
+        import random  # noqa: PLC0415
+        from .preview_worker import PreviewWorker  # noqa: PLC0415
+
+        sample_paths = random.sample(self._files, min(10, len(self._files)))
+        self._preview_btn.setEnabled(False)
+        self._preview_btn.setText("処理中...")
+        self._preview_worker = PreviewWorker(sample_paths, self.current_options, len(self._files))
+        self._preview_worker.finished.connect(
+            lambda samples, mb: self._on_preview_done(samples, mb)
+        )
+        self._preview_worker.error.connect(self._on_preview_error)
+        self._preview_worker.start()
+
+    def _on_preview_done(self, samples: list, estimated_mb: float) -> None:
+        from .preview_dialog import ImagePreviewDialog  # noqa: PLC0415
+        self._preview_btn.setEnabled(True)
+        self._preview_btn.setText("🔍  仕上がり確認")
+        ImagePreviewDialog(samples, estimated_mb, len(self._files), parent=self).exec()
+
+    def _on_preview_error(self, msg: str) -> None:
+        self._preview_btn.setEnabled(True)
+        self._preview_btn.setText("🔍  仕上がり確認")
+        from PySide6.QtWidgets import QMessageBox  # noqa: PLC0415
+        QMessageBox.warning(self, "プレビューエラー", msg)
 
     def _on_ocr_clicked(self) -> None:
         self._ocr_btn.setEnabled(False)


### PR DESCRIPTION
Add a "仕上がり確認" button in Step 2 that samples up to 10 images, applies the current processing settings (contrast/resize), and shows a Before/After comparison dialog. The dialog also displays an estimated PDF image size based on average JPEG size across the samples.

<img width="1062" height="812" alt="image" src="https://github.com/user-attachments/assets/30f18eee-0396-4007-99d1-4cb281fd0e54" />

<img width="1918" height="471" alt="image" src="https://github.com/user-attachments/assets/ce4a2f6e-94e2-4d2d-bf8d-3149e3a4636a" />
